### PR TITLE
[BUG] Fixes trait return type and package name.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "sensor_shim_template"
-version = "0.1.0"
+name = "bus_interface"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub trait SensorInterface {
     
     fn get_status(&self) -> SensorStatus;
 
-    fn soft_reset(&mut self) -> bool;
+    fn soft_reset(&mut self) -> SensorStatus;
 
     fn get_format(&self) -> &'static str;
 
@@ -78,8 +78,8 @@ impl SensorInterface for ExampleSensor {
         return SensorStatus::Ready;
     }
 
-    fn soft_reset(&mut self) -> bool {
-        return true;
+    fn soft_reset(&mut self) -> SensorStatus {
+        return SensorStatus::Busy;
     }
 
     fn get_format(&self) -> &'static str {
@@ -123,7 +123,7 @@ mod sensor_interface_tests {
         assert_eq!(exam.get_name(), SENSOR_NAME);
         assert_eq!(exam.get_format(), READING_TYPES);
         assert_eq!(exam.get_data_names(), READING_NAMES);
-        assert_eq!(exam.soft_reset(), true);
+        assert_eq!(exam.soft_reset(), SensorStatus::Busy);
         assert_eq!(exam.get_status(), SensorStatus::Ready);
     }
 }


### PR DESCRIPTION
The package name needs to be updated in the cargo.toml file to the repo's name for consistency.

Also this PR changes the return type of the 'soft_reset' trait so it requires the SensorStatus enum.

This will allow the use of the SensorStatus enum for the Bus Controller as well as the SensorModules.