### PR TITLE
Update of fake_bus and lib

### DIFF
--- a/src/fake_bus.rs
+++ b/src/fake_bus.rs
@@ -15,6 +15,7 @@ const BYTES_IN_U32: usize = 4;
 pub struct FakeBus {
     tx_id: u32,
     rx_id: u32,
+    num_bytes: usize,
     msg_buffer: [u8; BUFFER_SIZE],
 }
 
@@ -23,6 +24,7 @@ impl FakeBus {
         let fb = FakeBus{
             tx_id: 0,
             rx_id: 1,
+            num_bytes: 0,
             msg_buffer: [0; BUFFER_SIZE],
         };
         return fb;
@@ -53,6 +55,9 @@ impl Bus for FakeBus {
             return Err(BusError::BadParameter);
         }
         
+        //set the number of bytes used.
+        self.num_bytes = num_bytes;
+
         //copy the id + data into the message_buffer, we do some bit shifting.
         let id_buf: [u8; BYTES_IN_U32];
 
@@ -106,6 +111,17 @@ mod fake_bus_tests {
     #[allow(unused_imports)]
     use super::*;
 
+    //let mut fb = FakeBus::new();
+    //let mut msg_data: [u8; 8] = [0; 8];
+
+    #[macro_export]
+    macro_rules! setup {
+        ($($x:expr), *) => {
+            let mut fb = FakeBus::new();
+            let msg_data: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+        };
+    }
+
     #[test]
     fn check_self() {
         assert!(true);
@@ -139,6 +155,7 @@ mod fake_bus_tests {
 
         //indicate we only want to read 1 byte
         assert!(fb.send_message(fb.rx_id, &msg_data, 1).is_ok());
+        assert!(fb.num_bytes == 1);
         
         let result = fb.receive_message();
         assert!(result.is_ok());
@@ -210,5 +227,10 @@ mod fake_bus_tests {
         //indicate we only want to read 1 byte
         assert!(fb.send_message(fb.rx_id, &msg_data, 1).is_ok());
         assert!(fb.spy_id() == fb.rx_id);
+    }
+
+    #[test]
+    fn num_bytes() {
+
     }
 }

--- a/src/fake_bus.rs
+++ b/src/fake_bus.rs
@@ -118,7 +118,7 @@ mod fake_bus_tests {
         let data: [u8; 8]; 
         (rx_id, data) = result.unwrap();
 
-        assert!(rx_id == 0);
+        assert!(rx_id == 1);
         assert!(data == msg_data);
     }
 
@@ -141,7 +141,7 @@ mod fake_bus_tests {
         let data: [u8; 8]; 
         (rx_id, data) = result.unwrap();
 
-        assert!(rx_id == 0);
+        assert!(rx_id == 1);
         assert!(data == msg_data);
     }
 

--- a/src/fake_bus.rs
+++ b/src/fake_bus.rs
@@ -110,6 +110,7 @@ mod fake_bus_tests {
         
         //set the actual data into it
         msg_data[0] = 1;
+        msg_data[1] = 6;
 
         //indicate we only want to read 1 byte
         assert!(fb.send_message(fb.id, &msg_data, 1).is_ok());

--- a/src/fake_bus.rs
+++ b/src/fake_bus.rs
@@ -28,7 +28,7 @@ impl FakeBus {
     }
 
     //Returns the data bytes from the message.
-    pub fn spy_data(self) -> [u8; 8] {
+    pub fn spy_data(&self) -> [u8; 8] {
         let mut spy_data: [u8; 8] = [0; 8];
         spy_data.copy_from_slice(&self.msg_buffer[4..(8 + 4)]);
         return spy_data;

--- a/src/fake_bus.rs
+++ b/src/fake_bus.rs
@@ -12,14 +12,16 @@ const LITTLE_ENDIAN: bool = true;
 
 #[allow(dead_code)]
 pub struct FakeBus {
-    id: u32,
+    tx_id: u32,
+    rx_id: u32,
     msg_buffer: [u8; BUFFER_SIZE],
 }
 
 impl FakeBus {
     pub fn new() -> FakeBus {
         let fb = FakeBus{
-            id: 0,
+            tx_id: 0,
+            rx_id: 1,
             msg_buffer: [0; BUFFER_SIZE],
         };
         return fb;
@@ -107,7 +109,7 @@ mod fake_bus_tests {
     fn send_receive() {
         let mut fb = FakeBus::new();
         let msg_data: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
-        assert!(fb.send_message(fb.id, &msg_data, 8).is_ok());
+        assert!(fb.send_message(fb.rx_id, &msg_data, 8).is_ok());
         
         let result = fb.receive_message();
         assert!(result.is_ok());
@@ -130,7 +132,7 @@ mod fake_bus_tests {
         msg_data[1] = 6;
 
         //indicate we only want to read 1 byte
-        assert!(fb.send_message(fb.id, &msg_data, 1).is_ok());
+        assert!(fb.send_message(fb.rx_id, &msg_data, 1).is_ok());
         
         let result = fb.receive_message();
         assert!(result.is_ok());
@@ -153,7 +155,7 @@ mod fake_bus_tests {
         msg_data[1] = 6;
 
         //indicate we only want to read 1 byte
-        assert!(fb.send_message(fb.id, &msg_data, 9).is_ok() == false);
+        assert!(fb.send_message(fb.rx_id, &msg_data, 9).is_ok() == false);
     }
 
     #[test]
@@ -179,7 +181,7 @@ mod fake_bus_tests {
         msg_data[0] = 1;
 
         //indicate we only want to read 1 byte
-        assert!(fb.send_message(fb.id, &msg_data, 1).is_ok());
+        assert!(fb.send_message(fb.rx_id, &msg_data, 1).is_ok());
        
         //check that we can spy on the sent data.
         let spy_data = fb.spy_data();
@@ -198,7 +200,7 @@ mod fake_bus_tests {
         msg_data[0] = 1;
 
         //indicate we only want to read 1 byte
-        assert!(fb.send_message(fb.id, &msg_data, 1).is_ok());
-        assert!(fb.spy_id() == fb.id);
+        assert!(fb.send_message(fb.rx_id, &msg_data, 1).is_ok());
+        assert!(fb.spy_id() == fb.rx_id);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ include!("fake_bus.rs");
 const SEND_BUFFER_BYTES: usize = 8;
 const READ_BUFFER_BYTES: usize = 8;
 
+// The Errors that we allow as result's
 #[derive(Debug)]
 pub enum BusError {
     Unknown,
@@ -90,10 +91,17 @@ pub enum BusStatus {
     Error,
 }
 
-pub fn command_handler(bus: &mut dyn Bus, cmd: &ControllerCommand, _sens: &mut dyn SensorInterface) {
+
+// Used by the BUS Master/Controller
+pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand, _sens: &mut dyn SensorInterface) {
     match cmd {
         ControllerCommand::NameRequest => {
-            //bus.send_message()
+            let mut data: [u8; SEND_BUFFER_BYTES] = [0; SEND_BUFFER_BYTES];
+            data[0] = ControllerCommand::NameRequest as u8;
+            let result = bus.send_message(0, &data);
+            
+            //impliment a timeout
+
         }
         ControllerCommand::StatusRequest => {
 
@@ -217,7 +225,7 @@ mod sensor_interface_tests {
             data: [0x0F, 0xAA, 0x00, 0x55],
         }; 
 
-        let mut exam = ExampleSensor {
+        let exam = ExampleSensor {
             sensor_name: SENSOR_NAME,
             data_types: READING_TYPES,
             data_names: READING_NAMES,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ mod sensor_interface_tests {
         assert_eq!(ControllerCommand::from(val), ControllerCommand::NameRequest);
     }
 
-    //#[test]
+    #[test]
     fn read_name_command() {
         
         let sd = SensorData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ const MAX_WAIT_MS: u32 = 500;
 const SEND_BUFFER_BYTES: usize = 8;
 const READ_BUFFER_BYTES: usize = 8;
 const CRONTROLLER_ID: u32 = 0;
-
+const CONTROLLER_BUFFER: usize = 256;
 
 // The Errors that we allow as result's
 #[derive(Debug)]
@@ -234,7 +234,7 @@ mod sensor_interface_tests {
         assert_eq!(ControllerCommand::from(val), ControllerCommand::NameRequest);
     }
 
-    #[test]
+    //#[test]
     fn read_name_command() {
         
         let sd = SensorData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub enum BusStatus {
 
 
 // Used by the BUS Master/Controller
-pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand, _sens: &mut dyn SensorInterface) -> Result<(), BusStatus>{
+pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand) -> Result<(), BusStatus>{
     match cmd {
         ControllerCommand::NameRequest => {
             let mut data: [u8; SEND_BUFFER_BYTES] = [0; SEND_BUFFER_BYTES];
@@ -131,6 +131,10 @@ pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand, _sens: &mut 
     }
 }
 
+
+pub fn handle_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand, _sens: &mut dyn SensorInterface) -> Result<(), BusStatus>{
+    Ok(())
+}
 
 #[allow(dead_code)]
 pub struct SensorData {
@@ -240,8 +244,9 @@ mod sensor_interface_tests {
         let mut fake_bus = FakeBus::new();
 
         //make the request using the fake bus.
-        let cmd_result = send_bus_command(&mut fake_bus, &ControllerCommand::NameRequest, &mut exam);
+        let cmd_result = send_bus_command(&mut fake_bus, &ControllerCommand::NameRequest);
         assert!(cmd_result.is_ok());
+
 
         //now check the send data.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ const READ_BUFFER_BYTES: usize = 8;
 pub enum BusError {
     Unknown,
     BadParameter,
+    BusError,
 }
 
 //A simplified bus setup. Will define wrappers for a variety of busses 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,13 @@ const READ_BUFFER_BYTES: usize = 8;
 #[derive(Debug)]
 pub enum BusError {
     Unknown,
+    BadParameter,
 }
 
 //A simplified bus setup. Will define wrappers for a variety of busses 
 //elsewhere.
 pub trait Bus{
-    fn send_message(&mut self, id: u32, data: &[u8; SEND_BUFFER_BYTES]) -> Result<(), BusError>;
+    fn send_message(&mut self, id: u32, data: &[u8; SEND_BUFFER_BYTES], data_len: usize) -> Result<(), BusError>;
     fn receive_message(&mut self) -> Result<(u32, [u8; READ_BUFFER_BYTES]), BusError>;
 }
 
@@ -96,10 +97,10 @@ pub enum BusStatus {
 pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand, _sens: &mut dyn SensorInterface) {
     match cmd {
         ControllerCommand::NameRequest => {
-            let mut data: [u8; SEND_BUFFER_BYTES] = [0; SEND_BUFFER_BYTES];
-            data[0] = ControllerCommand::NameRequest as u8;
-            let result = bus.send_message(0, &data);
-            
+            //let mut data: [u8; SEND_BUFFER_BYTES] = [0; SEND_BUFFER_BYTES];
+            //data[0] = ControllerCommand::NameRequest as u8;
+            //let result = bus.send_message(0, &data, 8);
+
             //impliment a timeout
 
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,36 +95,38 @@ pub enum BusStatus {
 
 
 // Used by the BUS Master/Controller
-pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand, _sens: &mut dyn SensorInterface) {
+pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand, _sens: &mut dyn SensorInterface) -> Result<(), BusStatus>{
     match cmd {
         ControllerCommand::NameRequest => {
-            //let mut data: [u8; SEND_BUFFER_BYTES] = [0; SEND_BUFFER_BYTES];
-            //data[0] = ControllerCommand::NameRequest as u8;
-            //let result = bus.send_message(0, &data, 8);
-
+            let mut data: [u8; SEND_BUFFER_BYTES] = [0; SEND_BUFFER_BYTES];
+            data[0] = ControllerCommand::NameRequest as u8;
+            let result = bus.send_message(0, &data, 8);
+            if result.is_ok() {
+                return Ok(())
+            }
             //impliment a timeout
-
+            return Err(BusStatus::Error)
         }
         ControllerCommand::StatusRequest => {
-
+            Ok(())
         }
         ControllerCommand::ResetRequest => {
-
+            Ok(())
         }
         ControllerCommand::FormatingRequest => {
-
+            Ok(())
         }
         ControllerCommand::DnamesRequest => {
-
+            Ok(())
         }
         ControllerCommand::DataRequest => {
-
+            Ok(())
         }
         ControllerCommand::BulkRequest => {
-
+            Ok(())
         }
         ControllerCommand::BadCommand => {
-
+            Ok(())
         }
     }
 }
@@ -227,12 +229,21 @@ mod sensor_interface_tests {
             data: [0x0F, 0xAA, 0x00, 0x55],
         }; 
 
-        let exam = ExampleSensor {
+        let mut exam = ExampleSensor {
             sensor_name: SENSOR_NAME,
             data_types: READING_TYPES,
             data_names: READING_NAMES,
             data: sd,
         };
+
+        //create a fake bus instance
+        let mut fake_bus = FakeBus::new();
+
+        //make the request using the fake bus.
+        let cmd_result = send_bus_command(&mut fake_bus, &ControllerCommand::NameRequest, &mut exam);
+        assert!(cmd_result.is_ok());
+
+        //now check the send data.
 
     }
 }


### PR DESCRIPTION
closes #15 #13 

Added some spy functions to the fake_bus that allows "spying" on the send/received data and id's during testing.

The function in the fake bus for sending now takes an additional parameter called `num_bytes: usize` that allows more efficient bus usage.

