### PR TITLE
Refactored to use vectors

### DIFF
--- a/src/fake_bus.rs
+++ b/src/fake_bus.rs
@@ -143,8 +143,13 @@ mod fake_bus_tests {
         (rx_id, data) = result.unwrap();
 
         assert!(rx_id == 1);
-        assert!(data == msg_data);
+        assert!(data.len() == msg_data.len());
+        
+        for i in 0..msg_data.len() {
+            assert!(data[i] == msg_data[i]);
+        }
     }
+
 
     #[test]
     fn send_receivce_single_byte() {

--- a/src/fake_bus.rs
+++ b/src/fake_bus.rs
@@ -32,8 +32,12 @@ impl FakeBus {
 
     //Returns the data bytes from the message.
     pub fn spy_data(&self) -> Vec<u8> {
-        let mut spy_data: Vec<u8> = vec!(0, 0, 0, 0, 0, 0, 0, 0);
-        spy_data.copy_from_slice(&self.msg_buffer[4..(8 + 4)]);
+        let mut spy_data: Vec<u8> = vec![];
+        let start: usize = BYTES_IN_U32;
+        let end: usize = self.msg_size + BYTES_IN_U32;
+        for i in start..end{
+            spy_data.push(self.msg_buffer[i]);
+        }
         return spy_data;
     }
 
@@ -199,17 +203,14 @@ mod fake_bus_tests {
     #[test]
     fn spy_data() {
         let mut fb = FakeBus::new();
-        let mut msg_data: Vec<u8> = vec!(0, 0, 0, 0, 0, 0, 0, 0);
+        let msg_data: Vec<u8> = vec!(1, 1, 7);
 
-        //set the actual data into it
-        msg_data[0] = 1;
-
-        //indicate we only want to read 1 byte
         assert!(fb.send_message(fb.rx_id, &msg_data).is_ok());
        
         //check that we can spy on the sent data.
         let spy_data = fb.spy_data();
         println!("Spy_data: {:?}", spy_data);
+        println!("orig data: {:?}", msg_data);
         
         assert!(spy_data == msg_data);
 

--- a/src/fake_bus.rs
+++ b/src/fake_bus.rs
@@ -5,6 +5,8 @@
  * Description: A fake implimentation of a bus for testing.
  */
 
+use std::io;
+
 const BUFFER_SIZE: usize = 32;
 const MIN_ID: u32 =  0;
 const MAX_ID: u32 = 128;
@@ -99,7 +101,7 @@ impl Bus for FakeBus {
 
 
         //copy the message into the data array.
-        for i in 0..self.msg_size {
+        for i in BYTES_IN_U32..(self.msg_size + BYTES_IN_U32) {
             data.push(self.msg_buffer[i]);
         }
 
@@ -146,6 +148,8 @@ mod fake_bus_tests {
         assert!(data.len() == msg_data.len());
         
         for i in 0..msg_data.len() {
+            println!("sent[{}]: {}", i, msg_data[i]);
+            println!("received[{}]: {}", i, data[i]);
             assert!(data[i] == msg_data[i]);
         }
     }

--- a/src/fake_bus.rs
+++ b/src/fake_bus.rs
@@ -5,8 +5,6 @@
  * Description: A fake implimentation of a bus for testing.
  */
 
-use std::io;
-
 const BUFFER_SIZE: usize = 32;
 const MIN_ID: u32 =  0;
 const MAX_ID: u32 = 128;
@@ -148,8 +146,6 @@ mod fake_bus_tests {
         assert!(data.len() == msg_data.len());
         
         for i in 0..msg_data.len() {
-            println!("sent[{}]: {}", i, msg_data[i]);
-            println!("received[{}]: {}", i, data[i]);
             assert!(data[i] == msg_data[i]);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,4 +320,9 @@ mod sensor_interface_tests {
         assert_eq!(fake_bus.spy_data(), exam.sensor_name.as_bytes());
 
     }
+
+    #[test]
+    fn status_request() {
+        assert!(true);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,11 +162,6 @@ pub fn handle_bus_command(slv_id: u32, bus: &mut dyn Bus, sens: &mut dyn SensorI
             //send the data.              
             bus.send_message(slv_id, &write_buf)?;
 
-            //clear the buffer.
-            for elem in write_buf.iter_mut() {
-                *elem = 0x00;
-            }
-
         }
         ControllerCommand::StatusRequest => {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ mod sensor_interface_tests {
 
     #[test]
     fn read_name_command() {
-        let slv_id: u32 = 0x001; 
+        let id: u32 = 0x001; 
         let mut td = setup();
 
         /* SERVER SIDE ACTIONS */
@@ -328,7 +328,7 @@ mod sensor_interface_tests {
         /* CLIENT SIDE ACTIONS */
         
         //read the message.
-        let handler_result = handle_bus_command(slv_id, &mut td.bus, &mut td.sens);
+        let handler_result = handle_bus_command(id, &mut td.bus, &mut td.sens);
         assert!(handler_result.is_ok());
 
         //check that the data is sent back.
@@ -338,6 +338,11 @@ mod sensor_interface_tests {
 
     #[test]
     fn status_request() {
-        assert!(true);
+        let mut td = setup();
+        
+        let cmd_result = send_bus_command(&mut td.bus, &ControllerCommand::StatusRequest);
+        assert!(cmd_result.is_ok());
+        
+
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,18 @@
-#![cfg_attr(not(test), no_std)]
+//#![cfg_attr(test)]
+//#![no_std]
+
 
 /* Only include the fake/mocked when testing. */
 #[cfg(test)]
 include!("fake_bus.rs");
 
-const MAX_NAME_BYTES_LEN: usize = 64;
-const MAX_WAIT_MS: u32 = 500;
+
+const _MAX_NAME_BYTES_LEN: usize = 64;
+const _MAX_WAIT_MS: u32 = 500;
 const SEND_BUFFER_BYTES: usize = 8;
 const READ_BUFFER_BYTES: usize = 8;
 const CRONTROLLER_ID: u32 = 0;
-const CONTROLLER_BUFFER: usize = 256;
+const _CONTROLLER_BUFFER: usize = 256;
 
 // The Errors that we allow as result's
 #[derive(Debug)]
@@ -22,8 +25,8 @@ pub enum BusError {
 //A simplified bus setup. Will define wrappers for a variety of busses 
 //elsewhere.
 pub trait Bus{
-    fn send_message(&mut self, id: u32, data: &[u8; SEND_BUFFER_BYTES], data_len: usize) -> Result<(), BusError>;
-    fn receive_message(&mut self) -> Result<(u32, [u8; READ_BUFFER_BYTES]), BusError>;
+    fn send_message(&mut self, id: u32, data: &Vec<u8>) -> Result<(), BusError>;
+    fn receive_message(&mut self) -> Result<(u32, Vec<u8>), BusError>;
 }
 
 
@@ -102,9 +105,9 @@ pub enum BusStatus {
 pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand) -> Result<(), BusStatus>{
     match cmd {
         ControllerCommand::NameRequest => {
-            let mut data: [u8; SEND_BUFFER_BYTES] = [0; SEND_BUFFER_BYTES];
+            let mut data: Vec<u8> = Vec::with_capacity(SEND_BUFFER_BYTES);
             data[0] = ControllerCommand::NameRequest as u8;
-            let result = bus.send_message(CRONTROLLER_ID, &data, 1);
+            let result = bus.send_message(CRONTROLLER_ID, &data);
             if result.is_ok() {
                 return Ok(())
             }
@@ -135,12 +138,59 @@ pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand) -> Result<()
     }
 }
 
-
-pub fn handle_bus_command(bus: &mut dyn Bus,_sens: &mut dyn SensorInterface) -> Result<(), BusStatus>{
+//Used by the slave device.
+pub fn handle_bus_command(slv_id: u32, bus: &mut dyn Bus, sens: &mut dyn SensorInterface) -> Result<(), BusError>{
+    
     //get the cmd out of the message.
-    let result = bus.receive_message();
+    let result = bus.receive_message()?;
+    let master_id: u32;
+    let mut master_data: Vec<u8> = Vec::with_capacity(8);
+    (master_id, master_data) = result;
+    let cmd: ControllerCommand = master_data[0].into();
 
-    //check/handle possible errors.
+    //match the command so we can call a handler.
+    match cmd {
+        ControllerCommand::NameRequest => {
+            //get the data from the sensor interface.
+            let write_buf_slice = sens.get_name().as_bytes();
+            let mut write_buf: Vec<u8> = Vec::with_capacity(8);
+            write_buf.copy_from_slice(write_buf_slice);
+
+            //send the data.              
+            bus.send_message(slv_id, &write_buf)?;
+
+            //clear the buffer.
+            for elem in write_buf.iter_mut() {
+                *elem = 0x00;
+            }
+
+        }
+        ControllerCommand::StatusRequest => {
+
+        }
+        ControllerCommand::ResetRequest => {
+
+        }
+        ControllerCommand::FormatingRequest => {
+
+        }
+        ControllerCommand::DnamesRequest => {
+
+        }
+        ControllerCommand::BulkRequest => {
+
+        }
+        ControllerCommand::DataRequest => {
+
+        }
+        ControllerCommand::BadCommand => {
+
+        }
+    }
+
+    //After processing then send the data.
+    //Bus::send_message(
+
     Ok(()) 
 }
 
@@ -236,7 +286,7 @@ mod sensor_interface_tests {
 
     #[test]
     fn read_name_command() {
-        
+        let slv_id: u32 = 0x001; 
         let sd = SensorData {
             data: [0x0F, 0xAA, 0x00, 0x55],
         }; 
@@ -265,7 +315,7 @@ mod sensor_interface_tests {
         /* CLIENT SIDE ACTIONS */
         
         //read the message.
-        let handler_result = handle_bus_command(&mut fake_bus, &mut exam);
+        let handler_result = handle_bus_command(slv_id, &mut fake_bus, &mut exam);
         assert!(handler_result.is_ok());
 
         //check that the data is sent back.


### PR DESCRIPTION
This PR closes #17 by including the needed `setup()` function to reduce the test complexity.

It also features the change from using statically sized arrays to using vectors.