### PR TITLE
Added new struct as the general return type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+#bxcan = {version = "0.5", optional = true}
+#socketcan = {version = "0.3", optional = true}
+
+[dev-dependencies]
+
+
+
+[features]
+#default = ["can_mock"]
+#can_mock = ["can_mock"] 
+#default = ["socketcan"]
+#bxcan = ["bxcan_impl"]
+#socketcan = ["socketcan_impl"] 
+

--- a/src/can_mock.rs
+++ b/src/can_mock.rs
@@ -6,3 +6,16 @@ pub trait BlockingCan {
     fn transmit(&mut self, frame: &Self::Frame) -> Result<(), Self::Error>;
     fn receive(&mut self) -> Result<Self::Frame, Self::Error>;
 }
+
+
+
+struct CanFrameStd {
+    sof: bool,
+    std_id: u16,
+    rtr: bool,
+    ide: bool
+    rb0: bool
+    dlc: u8,
+    data: [u8; 8],
+    crc: u16,
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,8 @@
+/*
+ * Authors: Jake G,
+ * Date: 2024
+ * Filename: client.rs
+ * Desc: File to be included for embedded devices. 
+ */
+
+

--- a/src/cmd_return.rs
+++ b/src/cmd_return.rs
@@ -1,0 +1,22 @@
+// The data that gets returned from the command requests.
+#![allow(dead_code)]
+#[derive(Debug)]
+pub struct CmdReturn {
+    name: String,
+    format: String,
+    data_names: String,
+    raw_bytes: Vec<u8>,
+}
+
+impl CmdReturn {
+    pub fn new() -> CmdReturn {
+        let ret = CmdReturn{
+            name: String::new(),
+            format: String::new(),
+            data_names: String::new(),
+            raw_bytes: vec![],
+        };
+        ret
+    }
+
+}

--- a/src/cmd_return.rs
+++ b/src/cmd_return.rs
@@ -18,5 +18,17 @@ impl CmdReturn {
         };
         ret
     }
+    
 
+}
+
+//Tests for the structure
+mod test_cmdreturn {
+    #![allow(unused_imports)]
+    use super::*;
+
+    #[test]
+    fn self_test() {
+        assert!(true);
+    }
 }

--- a/src/cmd_return.rs
+++ b/src/cmd_return.rs
@@ -26,9 +26,39 @@ impl CmdReturn {
 mod test_cmdreturn {
     #![allow(unused_imports)]
     use super::*;
+    
+    fn setup() -> CmdReturn {
+        let mut new_response = CmdReturn::new();
+        new_response.name = String::from("aht20");
+        new_response.format = String::from("u16 u16");
+        new_response.data_names = String::from("Temp Humid");
+        new_response.raw_bytes = vec!(0, 255, 0, 255);
+
+        new_response
+    }
 
     #[test]
     fn self_test() {
         assert!(true);
+    }
+
+    #[test]
+    fn test_name() {
+        let mut new_response = CmdReturn::new();
+        new_response.name = String::from("fake_sensor");
+        assert_eq!(new_response.name, String::from("fake_sensor"));
+    }
+
+    #[test]
+    fn parse_to_json() {
+        let ret = setup();
+        let correct_response = String::from("{\"name\":\"aht20\", \"Temp\":\"255\", \"Humid\":\"255\"}");
+        
+        //test list
+        //1. has parse function.
+        let json_str = ret.parse_to_json();
+
+        //2. outputs jason correctly.
+        assert_eq!(json_str, correct_response);
     }
 }

--- a/src/cmd_return.rs
+++ b/src/cmd_return.rs
@@ -3,7 +3,7 @@
 #[derive(Debug)]
 pub struct CmdReturn {
     name: String,
-    format: String,
+    format: Vec<String>,
     data_names: Vec<String>,
     raw_bytes: Vec<u8>,
 }
@@ -12,7 +12,7 @@ impl CmdReturn {
     pub fn new() -> CmdReturn {
         let ret = CmdReturn{
             name: String::new(),
-            format: String::new(),
+            format: vec![],
             data_names: vec![], 
             raw_bytes: vec![],
         };
@@ -24,17 +24,96 @@ impl CmdReturn {
         //1. add the name json.
         json.push_str("{\"name\":\"");
         json.push_str(&self.name);
-        json.push_str("\", ");
+        json.push_str("\"");
+
+        let data_strings = self.bytes_to_strings();
 
         //2. Add the data.
-        //. figure out how many vars of data we have.
+        for i in 0..self.data_names.len() {
+            json.push_str(", \"");
+            json.push_str(&self.data_names[i]);
+            json.push_str("\":\"");
+            json.push_str(&data_strings[i]);
+            json.push_str("\"");
+        }
+        
+        json.push_str("}");
+
         json
     }
 
-    fn num_vars(&self) -> usize {
-        return 0    
+    fn bytes_to_strings(&self) -> Vec<String> {
+        let mut data: Vec<String> = vec![]; 
+        let mut byte_index: usize = 0;
+        
+        for fmt in &self.format {
+            if fmt.contains("u8") {
+                data.push(format!("{}",self.raw_bytes[byte_index]));    
+                byte_index += 1;
+            }
+            else if fmt.contains("u16") {
+                let tmp: u16 = bytes_to_u16(&self.raw_bytes, byte_index);
+                data.push(format!("{}",tmp));    
+                byte_index += 2;
+            }
+
+            else if fmt.contains("i16") {
+                let tmp: i16 = bytes_to_i16(&self.raw_bytes, byte_index);
+                data.push(format!("{}",tmp));    
+                byte_index += 2;
+            }
+
+            else if fmt.contains("u32") {
+                let tmp: u32 = bytes_to_u32(&self.raw_bytes, byte_index);
+                data.push(format!("{}",tmp)); 
+                byte_index += 4;
+            }
+
+            else if fmt.contains("i32") {
+                let tmp: i32 = bytes_to_i32(&self.raw_bytes, byte_index);
+                data.push(format!("{}",tmp)); 
+                byte_index += 4;
+            }
+        }
+
+        data
     }
 
+}
+
+fn bytes_to_u16(b: &Vec<u8>, start: usize) -> u16 {
+        let tmp: u16 =
+            ((b[start] as u16 )<< 8) | 
+            (b[start + 1] as u16);
+        tmp
+}
+
+
+fn bytes_to_i16(b: &Vec<u8>, start: usize) -> i16 {
+        let tmp: i16 =
+            ((b[start] as i16 )<< 8) | 
+            (b[start + 1] as i16);
+        tmp
+}
+
+
+fn bytes_to_u32(b: &Vec<u8>, start: usize) -> u32 {
+    let tmp: u32 = 
+        ((b[start] as u32 )<< 24) | 
+        ((b[start + 1] as u32 )<< 16) | 
+        ((b[start + 2] as u32 )<< 8) | 
+        (b[start + 3] as u32);
+        tmp
+}
+
+
+fn bytes_to_i32(b: &Vec<u8>, start: usize) -> i32 {
+    let tmp: i32 = 
+        ((b[start] as i32 )<< 24) | 
+        ((b[start + 1] as i32 )<< 16) | 
+        ((b[start + 2] as i32 )<< 8) | 
+        (b[start + 3] as i32);
+        tmp
 }
 
 //Tests for the structure
@@ -45,7 +124,8 @@ mod test_cmdreturn {
     fn setup() -> CmdReturn {
         let mut new_response = CmdReturn::new();
         new_response.name = String::from("aht20");
-        new_response.format = String::from("u16 u16");
+        new_response.format.push(String::from("u16"));
+        new_response.format.push(String::from("u16"));
         new_response.data_names.push(String::from("Temp"));
         new_response.data_names.push(String::from("Humid"));
         new_response.raw_bytes = vec!(0, 255, 0, 255);

--- a/src/cmd_return.rs
+++ b/src/cmd_return.rs
@@ -1,5 +1,20 @@
 // The data that gets returned from the command requests.
 #![allow(dead_code)]
+
+
+//considering the use of this C style union.
+//it requires use of 'unsafe' and may not be the best choice.
+#[repr(C)]
+union UData {
+    du8: u8,
+    du16: u16,
+    du32: u32,
+    di8: i8,
+    di16: i16,
+    di32: i32,
+    df32: f32,
+}
+
 #[derive(Debug)]
 pub struct CmdReturn {
     name: String,

--- a/src/cmd_return.rs
+++ b/src/cmd_return.rs
@@ -4,7 +4,7 @@
 pub struct CmdReturn {
     name: String,
     format: String,
-    data_names: String,
+    data_names: Vec<String>,
     raw_bytes: Vec<u8>,
 }
 
@@ -13,12 +13,27 @@ impl CmdReturn {
         let ret = CmdReturn{
             name: String::new(),
             format: String::new(),
-            data_names: String::new(),
+            data_names: vec![], 
             raw_bytes: vec![],
         };
         ret
+    }  
+
+    pub fn parse_to_json(&self) -> String {
+        let mut json = String::new();
+        //1. add the name json.
+        json.push_str("{\"name\":\"");
+        json.push_str(&self.name);
+        json.push_str("\", ");
+
+        //2. Add the data.
+        //. figure out how many vars of data we have.
+        json
     }
-    
+
+    fn num_vars(&self) -> usize {
+        return 0    
+    }
 
 }
 
@@ -31,7 +46,8 @@ mod test_cmdreturn {
         let mut new_response = CmdReturn::new();
         new_response.name = String::from("aht20");
         new_response.format = String::from("u16 u16");
-        new_response.data_names = String::from("Temp Humid");
+        new_response.data_names.push(String::from("Temp"));
+        new_response.data_names.push(String::from("Humid"));
         new_response.raw_bytes = vec!(0, 255, 0, 255);
 
         new_response
@@ -42,6 +58,7 @@ mod test_cmdreturn {
         assert!(true);
     }
 
+
     #[test]
     fn test_name() {
         let mut new_response = CmdReturn::new();
@@ -49,8 +66,9 @@ mod test_cmdreturn {
         assert_eq!(new_response.name, String::from("fake_sensor"));
     }
 
+
     #[test]
-    fn parse_to_json() {
+    fn test_parse_to_json() {
         let ret = setup();
         let correct_response = String::from("{\"name\":\"aht20\", \"Temp\":\"255\", \"Humid\":\"255\"}");
         

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,8 +150,9 @@ pub fn handle_bus_command(slv_id: u32, bus: &mut dyn Bus, sens: &mut dyn SensorI
     
     //get the cmd out of the message.
     let result = bus.receive_message()?;
-    let mut id = 0;
-    let mut master_data: Vec<u8> = Vec::with_capacity(8);
+
+    let id;
+    let mut master_data: Vec<u8> = vec![]; 
     (id, master_data) = result;
     let cmd: ControllerCommand = master_data[0].into();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //#![cfg_attr(test)]
 //#![no_std]
 
+mod cmd_return;
+use cmd_return::CmdReturn;
 
 /* Only include the fake/mocked when testing. */
 #[cfg(test)]
@@ -10,12 +12,10 @@ include!("fake_bus.rs");
 const _MAX_NAME_BYTES_LEN: usize = 64;
 const _MAX_WAIT_MS: u32 = 500;
 const SEND_BUFFER_BYTES: usize = 8;
-const READ_BUFFER_BYTES: usize = 8;
+const _READ_BUFFER_BYTES: usize = 8;
 const CRONTROLLER_ID: u32 = 0;
 const _CONTROLLER_BUFFER: usize = 256;
 
-// The data that gets returned from the command requests.
-//TODO: add a rust union type here
 
 
 // The Errors that we allow as result's
@@ -106,38 +106,41 @@ pub enum BusStatus {
 
 
 // Used by the BUS Master/Controller
-pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand) -> Result<(), BusStatus>{
+pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand) -> Result<CmdReturn, BusStatus>{
+    
+    let ret = CmdReturn::new();
+
     match cmd {
         ControllerCommand::NameRequest => {
             let mut data: Vec<u8> = Vec::with_capacity(SEND_BUFFER_BYTES);
             data.push(ControllerCommand::NameRequest as u8);
             let result = bus.send_message(CRONTROLLER_ID, &data);
             if result.is_ok() {
-                return Ok(())
+                return Ok(ret);
             }
             //impliment a timeout
             return Err(BusStatus::Error)
         }
         ControllerCommand::StatusRequest => {
-            Ok(())
+            Ok(ret)
         }
         ControllerCommand::ResetRequest => {
-            Ok(())
+            Ok(ret)
         }
         ControllerCommand::FormatingRequest => {
-            Ok(())
+            Ok(ret)
         }
         ControllerCommand::DnamesRequest => {
-            Ok(())
+            Ok(ret)
         }
         ControllerCommand::DataRequest => {
-            Ok(())
+            Ok(ret)
         }
         ControllerCommand::BulkRequest => {
-            Ok(())
+            Ok(ret)
         }
         ControllerCommand::BadCommand => {
-            Ok(())
+            Ok(ret)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,10 @@ const READ_BUFFER_BYTES: usize = 8;
 const CRONTROLLER_ID: u32 = 0;
 const _CONTROLLER_BUFFER: usize = 256;
 
+// The data that gets returned from the command requests.
+//TODO: add a rust union type here
+
+
 // The Errors that we allow as result's
 #[derive(Debug)]
 pub enum BusError {
@@ -315,7 +319,6 @@ mod sensor_interface_tests {
         let mut td = setup();
 
         /* SERVER SIDE ACTIONS */
-        //make the request using the fake bus.
         let cmd_result = send_bus_command(&mut td.bus, &ControllerCommand::NameRequest);
         assert!(cmd_result.is_ok());
 
@@ -325,9 +328,7 @@ mod sensor_interface_tests {
         assert!(td.bus.spy_id() == 0);
         assert!(td.bus.spy_data()[0] == ControllerCommand::NameRequest as u8);
 
-        /* CLIENT SIDE ACTIONS */
-        
-        //read the message.
+        /* CLIENT SIDE ACTIONS */        
         let handler_result = handle_bus_command(id, &mut td.bus, &mut td.sens);
         assert!(handler_result.is_ok());
 
@@ -342,7 +343,7 @@ mod sensor_interface_tests {
         
         let cmd_result = send_bus_command(&mut td.bus, &ControllerCommand::StatusRequest);
         assert!(cmd_result.is_ok());
-        
-
+       
+        //check the received sensor status.
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,8 @@
+/*
+ * Authors: Jake G,
+ * Date: 2024
+ * Filename: server.rs
+ * Desc: File to be included for SBC(single board computer). 
+ */
+
+


### PR DESCRIPTION
closes #6 

This PR implements a struct that holds the bus data information. This encapsulates the information data as byte vector that can be parsed into json strings with one of it's methods.
