### PR TITLE
Adds in code for most of the bus_interface commands.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,12 @@ pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand) -> Result<Cm
             return Err(BusStatus::Error);
         }
         ControllerCommand::DnamesRequest => {
-            Ok(ret)
+            data.push(ControllerCommand::DnamesRequest as u8);
+            let result = bus.send_message(CRONTROLLER_ID, &data);
+            if result.is_ok() {
+                return Ok(ret);
+            }
+            return Err(BusStatus::Error);
         }
         ControllerCommand::DataRequest => {
             Ok(ret)
@@ -211,6 +216,14 @@ pub fn handle_bus_command(slv_id: u32, bus: &mut dyn Bus, sens: &mut dyn SensorI
 
         }
         ControllerCommand::DnamesRequest => {
+
+            let data_names = sens.get_data_names().as_bytes(); 
+            
+            for i in 0..data_names.len() {
+                write_buf.push(data_names[i]);
+            }
+
+            bus.send_message(slv_id, &write_buf)?;
 
         }
         ControllerCommand::BulkRequest => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,5 +349,7 @@ mod sensor_interface_tests {
         assert!(cmd_result.is_ok());
        
         //check the received sensor status.
+        let handler_result = handle_bus_command(0x001, &mut td.bus, &mut td.sens);
+        assert!(handler_result.is_ok());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,10 +226,10 @@ pub fn handle_bus_command(slv_id: u32, bus: &mut dyn Bus, sens: &mut dyn SensorI
             bus.send_message(slv_id, &write_buf)?;
 
         }
-        ControllerCommand::BulkRequest => {
+        ControllerCommand::DataRequest => {
 
         }
-        ControllerCommand::DataRequest => {
+        ControllerCommand::BulkRequest => {
 
         }
         ControllerCommand::BadCommand => {
@@ -452,4 +452,7 @@ mod sensor_interface_tests {
         //check the formatting sent back.
         assert_eq!(READING_NAMES.as_bytes() , td.bus.spy_data());
     }
+
+    #[test]
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,4 +423,22 @@ mod sensor_interface_tests {
         //check the formatting sent back.
         assert_eq!(READING_TYPES.as_bytes() , td.bus.spy_data());
     }
+
+    #[test]
+    fn data_names_request() {
+
+        let mut td = setup();
+        
+        let cmd_result = send_bus_command(&mut td.bus, &ControllerCommand::DnamesRequest);
+        assert!(cmd_result.is_ok());
+
+        assert!(td.bus.spy_id() == 0);
+        assert!(td.bus.spy_data()[0] == ControllerCommand::DnamesRequest as u8);
+
+        let handler_result = handle_bus_command(0x001, &mut td.bus, &mut td.sens);
+        assert!(handler_result.is_ok());
+
+        //check the formatting sent back.
+        assert_eq!(READING_NAMES.as_bytes() , td.bus.spy_data());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,13 @@ pub fn handle_bus_command(slv_id: u32, bus: &mut dyn Bus, sens: &mut dyn SensorI
 
         }
         ControllerCommand::FormatingRequest => {
+            let formatting = sens.get_format().as_bytes(); 
+            
+            for i in 0..formatting.len() {
+                write_buf.push(formatting[i]);
+            }
+
+            bus.send_message(slv_id, &write_buf)?;
 
         }
         ControllerCommand::DnamesRequest => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,4 +369,20 @@ mod sensor_interface_tests {
         //check the status was sent back.
         assert_eq!(td.bus.spy_data()[0], td.sens.get_status() as u8);
     }
+
+    #[test]
+    fn reset_request() {
+        let mut td = setup();
+        
+        let cmd_result = send_bus_command(&mut td.bus, &ControllerCommand::ResetRequest);
+        assert!(cmd_result.is_ok());
+
+        assert!(td.bus.spy_id() == 0);
+        assert!(td.bus.spy_data()[0] == ControllerCommand::StatusRequest as u8);
+
+        let handler_result = handle_bus_command(0x001, &mut td.bus, &mut td.sens);
+        assert!(handler_result.is_ok());
+
+
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,6 @@ pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand) -> Result<Cm
             if result.is_ok() {
                 return Ok(ret);
             }
-
             return Err(BusStatus::Error);
         }
         ControllerCommand::ResetRequest => {
@@ -136,10 +135,15 @@ pub fn send_bus_command(bus: &mut dyn Bus, cmd: &ControllerCommand) -> Result<Cm
             if result.is_ok() {
                 return Ok(ret);
             }
-            Ok(ret)
+            return Err(BusStatus::Error);
         }
         ControllerCommand::FormatingRequest => {
-            Ok(ret)
+            data.push(ControllerCommand::FormatingRequest as u8);
+            let result = bus.send_message(CRONTROLLER_ID, &data);
+            if result.is_ok() {
+                return Ok(ret);
+            }
+            return Err(BusStatus::Error);
         }
         ControllerCommand::DnamesRequest => {
             Ok(ret)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,8 +237,6 @@ pub fn handle_bus_command(slv_id: u32, bus: &mut dyn Bus, sens: &mut dyn SensorI
         }
     }
 
-    //After processing then send the data.
-    //Bus::send_message(
 
     Ok(()) 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,4 +394,22 @@ mod sensor_interface_tests {
         //check the status was sent back.
         assert_eq!(td.bus.spy_data()[0], td.sens.soft_reset() as u8);
     }
+
+    #[test]
+    fn formatting_request() {
+        
+        let mut td = setup();
+        
+        let cmd_result = send_bus_command(&mut td.bus, &ControllerCommand::FormatingRequest);
+        assert!(cmd_result.is_ok());
+
+        assert!(td.bus.spy_id() == 0);
+        assert!(td.bus.spy_data()[0] == ControllerCommand::FormatingRequest as u8);
+
+        let handler_result = handle_bus_command(0x001, &mut td.bus, &mut td.sens);
+        assert!(handler_result.is_ok());
+
+        //check the formatting sent back.
+        assert_eq!(READING_TYPES.as_bytes() , td.bus.spy_data());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,5 +454,21 @@ mod sensor_interface_tests {
     }
 
     #[test]
+    fn data_request() {
+        
+        let mut td = setup();
+        
+        let cmd_result = send_bus_command(&mut td.bus, &ControllerCommand::DataRequest);
+        assert!(cmd_result.is_ok());
+
+        assert!(td.bus.spy_id() == 0);
+        assert!(td.bus.spy_data()[0] == ControllerCommand::DataRequest as u8);
+
+        let handler_result = handle_bus_command(0x001, &mut td.bus, &mut td.sens);
+        assert!(handler_result.is_ok());
+
+        //check the formatting sent back.
+        //assert_eq!(READING_NAMES.as_bytes() , td.bus.spy_data());
+    }
 
 }


### PR DESCRIPTION
This PR closes #19 #20 #21 #23

It also adds the CmdReturn type file along with tests and the direct to json conversion code.

Also has the failing test for the data_request now implemented.