### PR TITLE
Cleaned up comments + feature setup for `bus_master` by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,8 @@ edition = "2021"
 [features]
 
 # Defines a feature named 'Bus Master'
-default = ["std"]
+default = ["bus_master"]
 
-std = []
 alloc = []
 bus_master = []
 sensor_module = []

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -4,7 +4,16 @@
  * Filename: handler.rs
  * Desc: File to be included for embedded devices. 
  */
-//#[cfg_attr(not(test), no_std)]
+
+/* Use an allocator if we aren't in a std enviroment or testing.*/
+#[cfg(any(not(test), feature = "sensor_module"))]
+extern crate alloc;
+
+#[cfg(any(not(test), feature = "sensor_module"))]
+use alloc::vec::Vec;
+
+#[cfg(any(not(test), feature = "sensor_module"))]
+use alloc::vec;
 
 
 pub fn handle_bus_command(slv_id: u32, bus: &mut dyn Bus, sens: &mut dyn SensorInterface) -> Result<(), BusError>{

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -4,6 +4,7 @@
  * Filename: handler.rs
  * Desc: File to be included for embedded devices. 
  */
+//#[cfg_attr(not(test), no_std)]
 
 
 pub fn handle_bus_command(slv_id: u32, bus: &mut dyn Bus, sens: &mut dyn SensorInterface) -> Result<(), BusError>{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,5 @@
 //Support using without the standard library
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-
-//#[cfg(feature = "alloc")]
-//extern crate alloc;
-
-//#![cfg(feature = "sensor_module")]
-//extern crate alloc;
-
-/* Include all the files when we test them. */
-
-#[cfg(test)]
-include!("fake_sensor.rs");
-
-#[cfg(test)]
-include!("fake_bus.rs");
-
-#[cfg(any(test, feature = "bus_master"))]
-include!("controller.rs");
-
-#[cfg(any(test, feature = "sensor_module"))]
-include!("handler.rs");
-
-
-
-//#[cfg(all(feature = "alloc", not(feature = "std")))]
-//pub use alloc::vec::Vec;
-//#[cfg(feature = "std")]
-//pub use std::vec::Vec;
-
+#![cfg_attr(all(not(feature = "bus_master"), not(test)), no_std)]
 
 
 const _MAX_NAME_BYTES_LEN: usize = 64;
@@ -129,4 +101,21 @@ pub struct SensorData {
     data: [u8; MAX_DATA],
     size: usize,
 }
+
+
+
+/* Include all the files when we test them. */
+
+#[cfg(test)]
+include!("fake_sensor.rs");
+
+#[cfg(test)]
+include!("fake_bus.rs");
+
+#[cfg(any(test, feature = "bus_master"))]
+include!("controller.rs");
+
+#[cfg(any(test, feature = "sensor_module"))]
+include!("handler.rs");
+
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //Support using without the standard library
-//#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
 //#[cfg(feature = "alloc")]
 //extern crate alloc;
@@ -18,7 +18,6 @@ include!("fake_bus.rs");
 #[cfg(any(test, feature = "bus_master"))]
 include!("controller.rs");
 
-//#[cfg(any(test, not(feature = "bus_master")))]
 #[cfg(any(test, feature = "sensor_module"))]
 include!("handler.rs");
 


### PR DESCRIPTION
This PR:

- Removes the `std` feature.
- Uses the `bus_master` feature by default now.
- Removes lots of commented out code.